### PR TITLE
Fix bug with comment boxes in Chrome

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -74,23 +74,25 @@ const replaceText = (textNode, input_word, replace_value) => {
 
 
 function walk(node, v, p){
-	// I stole this function from here:
+	// I stole the base to this function from here:
 	// http://is.gd/mwZp7E
-	var child, next;
-	switch (node.nodeType){
-		case 1:  // Element
-		case 9:  // Document
-		case 11: // Document fragment
-			child = node.firstChild;
-			while (child){
-				next = child.nextSibling;
-				walk(child, v, p);
-				child = next;
-			}
-			break;
-		case 3: // Text node
-			replaceText(node, v, p);
-			break;
+	if (node.contentEditable != 'true' && node.type != 'textarea' && node.type != 'input') {
+		var child, next;
+		switch (node.nodeType){
+			case 1:  // Element
+			case 9:  // Document
+			case 11: // Document fragment
+				child = node.firstChild;
+				while (child){
+					next = child.nextSibling;
+					walk(child, v, p);
+					child = next;
+				}
+				break;
+			case 3: // Text node
+				replaceText(node, v, p);
+				break;
+		}
 	}
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": 2,
   "name": "InteractiveFics",
   "author": "mariamrf",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Replaces Y/N & other variables in Reader Insert/second person fics with words of your choice.",
   "browser_action": {
   	"default_title": "InteractiveFics",


### PR DESCRIPTION
## Bug Description
When MutationObserver is, well, observing, we refresh the replacements whenever we detect a relevant mutation. This means that it gets triggered when we're editing/writing comments for example which ruins the way it's done (LTR becomes RTL, impossible to write a word, etc).

## Solution
Disable any replacements for any `contentEditable` elements or `textarea`s or `input` elements. This doesn't cover Facebook comments which are just weird divs but this + the feature being opt-in/can be disabled should be enough for now.